### PR TITLE
v0.1.1

### DIFF
--- a/jett_test.go
+++ b/jett_test.go
@@ -75,10 +75,10 @@ func TestSubrouter(t *testing.T) {
 
 func Home(w http.ResponseWriter, req *http.Request) {
 	params := PathParams(req)
-	JSONResponse(w, params, 200)
+	JSON(w, params, 200)
 }
 
 func About(w http.ResponseWriter, req *http.Request) {
 	params := QueryParams(req)
-	JSONResponse(w, params, 200)
+	JSON(w, params, 200)
 }


### PR DESCRIPTION
### Description - 

- Accept `ctx context.Context` in Run functions 

#### Run without context - 

```go
func (r *Router) Run(address string, onShutdownFns ...func())
```

```go
func (r *Router) RunTLS(address, certFile, keyFile string, onShutdownFns ...func())
```

#### Run with context - 

Useful when you need to pass a top-level context. Shutdown process will begin when the parent context cancels.

```go
func (r *Router) RunWithContext(ctx context.Context, address string, onShutdownFns ...func())
```

```go
func (r *Router) RunTLSWithContext(ctx context.Context, address, certFile, keyFile string, onShutdownFns ...func())
```

- Modified Response writers function names - `JSON`,  `XML`,  `TEXT`
