### PR TITLE
Essential Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ func main() {
 }
 
 func Home(w http.ResponseWriter, req *http.Request) {
-	JSON(w, "Hello World", 200)
+	jett.JSON(w, "Hello World", 200)
 }
 ```
 
@@ -155,15 +155,22 @@ func main() {
 	r := jett.New()
 
 	r.Use(middleware.RequestID)
-	r.Use(middleware.Logger)
 
 	r.GET("/", Home)
 
 	sr := r.Subrouter("/about")
-	sr.Use(middleware.NoCache)
-	sr.GET("/", About)
+	sr.Use(middleware.Logger)
+	sr.GET("/", About, middleware.NoCache)
 
 	r.Run(":8000")
+}
+
+func Home(w http.ResponseWriter, req *http.Request) {
+	jett.JSON(w, "Hello World", 200)
+}
+
+func About(w http.ResponseWriter, req *http.Request) {
+	jett.TEXT(w, "About", 200)
 }
 ```
 
@@ -353,7 +360,7 @@ Author and maintainer - [Saurabh Pujari](https://github.com/saurabh0719)
 Logo design - [Akhil Anil](https://twitter.com/adakidpv)
 
 Actively looking for Contributors to further improve upon this project. If you have any interesting ideas
-or feature suggestions, don't hesitate to open an issue! First thing on the To-do list is to add a few essential middleware in a separate `middleware/` package!
+or feature suggestions, don't hesitate to open an issue! 
 
 [Go back to the table of contents](#contents)
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,9 @@
 </div>
 <hr>
 
-Jett is a lightweight micro-framework for building Go HTTP services. Built on top of [HttpRouter](https://github.com/julienschmidt/httprouter). 
+Jett is a lightweight micro-framework for building Go HTTP services. It builds a layer on top of [HttpRouter](https://github.com/julienschmidt/httprouter) to enable subrouting and flexible addition of middleware at any level - root, subrouter, a specific route.
 
-Jett strives to be simple, without unnecessary abstractions, rather letting the router and methods from `net/http` shine. This allows Jett to be extremely flexible right out of the box. 
-
-The core framework is less than 300 loc but is designed to be easily extendable with middleware.
-<br><br><b>Coming soon -</b> Essential Middleware - BasicAuth, Logger, Recoverer, Blacklist IP, Throttle 
+Jett strives to be simple and easy to use with minimal abstractions. The core framework is less than 300 loc but is designed to be extendable with middleware. Comes packaged with a development server equipped for graceful shutdown and a few essential (optional) middleware.
 
 ```go
 package main
@@ -19,13 +16,14 @@ import (
 	"fmt"
 	"net/http"
 	"github.com/saurabh0719/jett"
+	"github.com/saurabh0719/jett/middleware"
 )
 
 func main() {
 
-	r := jett.New()
+	r := New()
 
-	r.Use(Logger)
+	r.Use(middleware.RequestID, middleware.Logger)
 
 	r.GET("/", Home)
 	
@@ -33,15 +31,7 @@ func main() {
 }
 
 func Home(w http.ResponseWriter, req *http.Request) {
-	jett.JSON(w, "Hello World", 200)
-}
-
-// Middleware
-func Logger(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		fmt.Printf("Middleware\n")
-		next.ServeHTTP(w, req)
-	})
+	JSON(w, "Hello World", 200)
 }
 ```
 
@@ -81,6 +71,18 @@ $ go get github.com/saurabh0719/jett
 
 ### Using Middleware 
 
+Jett supports any Middleware of the type `func(http.Handler) http.Handler`. 
+
+Some essential middleware are provided out of the box in `github.com/saurabh0719/jett/middleware` - 
+- `RequestID` : Injects a request ID into the context of each
+request
+
+- `Logger` : Log request paths, methods, status code as well as execution duration 
+- `Recoverer` : Recover and handle `panic` 
+- `NoCache` : Sets a number of HTTP headers to prevent
+a router (or subrouter) from being cached by an upstream proxy and/or client
+- `BasicAuth` : Basic Auth middleware, [RFC 2617, Section 2](https://www.rfc-editor.org/rfc/rfc2617.html#section-2)
+
 ```go
 func (r *Router) Use(middleware ...func(http.Handler) http.Handler)
 ```
@@ -88,11 +90,22 @@ func (r *Router) Use(middleware ...func(http.Handler) http.Handler)
 Middleware can be added at the at a Router level (root, subrouter) ... 
 
 ```go
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"github.com/saurabh0719/jett"
+	"github.com/saurabh0719/jett/middleware"
+)
+
 func main() {
 
 	r := jett.New()
 
-	r.GET("/", Home, Logger, Recover)
+	r.Use(middleware.RequestID, middleware.Logger)
+
+	r.GET("/", Home)
 	
 	r.Run(":8000")
 }
@@ -110,13 +123,11 @@ func main() {
 
 	r := jett.New()
 
-	r.GET("/", Home, Logger, Recover)
+	r.GET("/", Home, middleware.Logger, middleware.Recover)
 	
 	r.Run(":8000")
 }
 ```
-
-Compatible with any Middleware of the type `func(http.Handler) http.Handler`
 
 [Go back to the table of contents](#contents)
 
@@ -131,16 +142,25 @@ The `Subrouter` function returns a new `Router` instance.
 Example - 
 
 ```go 
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"github.com/saurabh0719/jett"
+	"github.com/saurabh0719/jett/middleware"
+)
 func main() {
 
 	r := jett.New()
 
-	r.Use(Logger)
+	r.Use(middleware.RequestID)
+	r.Use(middleware.Logger)
 
 	r.GET("/", Home)
 
 	sr := r.Subrouter("/about")
-	sr.Use(Recover)
+	sr.Use(middleware.NoCache)
 	sr.GET("/", About)
 
 	r.Run(":8000")
@@ -187,7 +207,7 @@ Path parameters -
 ```go
 // Helper function to extract path params from request Context()
 // as a map[string]string for easy access
-func PathParams(req *http.Request) map[string]string
+func URLParams(req *http.Request) map[string]string
 ```
 
 Query parameters - 
@@ -210,7 +230,7 @@ func main() {
 }
 
 func Person(w http.ResponseWriter, req *http.Request) {
-	params := jett.PathParams(req)
+	params := jett.URLParams(req)
 	
     // do something and prepare resp
 

--- a/jett.go
+++ b/jett.go
@@ -19,7 +19,6 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
-	"github.com/saurabh0719/jett/middleware"
 )
 
 // Jett package details

--- a/jett.go
+++ b/jett.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+	"github.com/saurabh0719/jett/middleware"
 )
 
 // Jett package details
@@ -176,7 +177,7 @@ func (r *Router) OPTIONS(path string, handlerFn http.HandlerFunc, middleware ...
 
 // Helper function to extract path params from request Context()
 // as a map[string]string for easy access
-func PathParams(req *http.Request) map[string]string {
+func URLParams(req *http.Request) map[string]string {
 
 	var routerParams httprouter.Params
 	routerParams = httprouter.ParamsFromContext(req.Context())
@@ -243,11 +244,7 @@ func (r *Router) runServer(ctx context.Context, address, certFile, keyFile strin
 	fmt.Println(banner)
 	fmt.Println(website)
 
-	if !isTLS && address[:1] == ":" {
-		fmt.Printf("Running Jett Server v%s, address -> http://127.0.0.1%s\n", Version, address)
-	} else {
-		fmt.Printf("Running Jett Server v%s, address -> %s\n", Version, address)
-	}
+	fmt.Printf("Running Jett Server v%s, address -> %s\n\n", Version, address)
 
 	// Stop the server on signal notif or when parent ctx cancels
 	select {
@@ -373,4 +370,4 @@ func XML(w http.ResponseWriter, data interface{}, status int) {
 	w.Write(xmlData)
 }
 
-// Coming soon - helpers for templates/static files & essential middlewares!
+// Coming soon - helpers for templates/static files

--- a/jett_test.go
+++ b/jett_test.go
@@ -30,11 +30,11 @@ func TestPathParams(t *testing.T) {
 	body, err := ioutil.ReadAll(res.Body)
 
 	// Convert []byte to map
-	var pathParams map[string]string
-	json.Unmarshal(body, &pathParams)
+	var urlParams map[string]string
+	json.Unmarshal(body, &urlParams)
 
-	if pathParams["param"] != "hello" {
-		t.Fatalf("PathParams -> Expected : [param] hello")
+	if urlParams["param"] != "hello" {
+		t.Fatalf("URLParams -> Expected : [param] hello")
 	}
 
 }
@@ -74,7 +74,7 @@ func TestSubrouter(t *testing.T) {
 }
 
 func Home(w http.ResponseWriter, req *http.Request) {
-	params := PathParams(req)
+	params := URLParams(req)
 	JSON(w, params, 200)
 }
 

--- a/middleware/basicauth.go
+++ b/middleware/basicauth.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"net/http"
+)
+
+// BasicAuth middleware - Implements middleware handler
+// RFC 2617, Section 2. (https://www.rfc-editor.org/rfc/rfc2617.html#section-2)
+// Ref - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate
+
+func BasicAuth(realm string, credentials map[string]string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			username, password, ok := req.BasicAuth()
+			if !ok {
+				unauthorized(w, realm)
+				return
+			}
+
+			// Verify
+			validPassword, found := credentials[username]
+			if !found || subtle.ConstantTimeCompare([]byte(password), []byte(validPassword)) != 1 {
+				unauthorized(w, realm)
+				return
+			}
+
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+// responds with 401 Unauthorized 
+func unauthorized(w http.ResponseWriter, realm string) {
+	// Set WWW-Authenticate header
+	w.Header().Add("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, realm))
+	w.WriteHeader(http.StatusUnauthorized) // 401
+}

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -1,0 +1,89 @@
+package middleware 
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Wraps http.ResponseWriter to allow us to store Status Code
+type responseWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+  
+func wrapWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{
+		ResponseWriter: w,
+	}
+}
+  
+func (rw *responseWriter) Status() int {
+	return rw.status
+}
+  
+// Implement WriteHeader for registering status code 
+func (rw *responseWriter) WriteHeader(code int) {
+	if rw.wroteHeader {
+	  return
+	}
+  
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+	rw.wroteHeader = true
+  
+	return
+}
+
+func Logger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request){
+		
+		// Get unique requestID from request Context
+		requestID := GetRequestID(req.Context())
+
+		// START
+		start := ""
+		if requestID != "" {
+			start = "START RequestID: " + requestID
+		} else {
+			start = "START RequestID: <nil>"
+		}
+		log.Print(start + " - " + req.Method + " " + req.URL.String())
+
+		// register start time
+		t1 := time.Now()
+
+		// Wrap http.ResponseWriter
+		wrapped := wrapWriter(w)
+
+		// Call downstream handlers
+		next.ServeHTTP(wrapped, req)
+
+		// register end time
+		t2 := time.Now()
+
+		// END
+		end := ""
+		if requestID != "" {
+			end = "END RequestID: " + requestID
+		} else {
+			end = "END RequestID: <nil>"
+		}
+
+		// Prepare duration log 
+		duration := ""
+		d := t2.Sub(t1)
+		duration = "Duration: "  + d.String()
+
+		// Prepare final log with Status code
+		status := wrapped.Status()
+		if status > 99 && status < 600 {
+			log.Printf(end + " - " + "Status: " + strconv.Itoa(status) + ", " + duration + "\n")
+		} else {
+			log.Printf(end + " - " + duration + "\n")
+		}
+		
+	})
+}

--- a/middleware/nocache.go
+++ b/middleware/nocache.go
@@ -1,0 +1,58 @@
+package middleware
+
+// Adapted from Goji's nocache middleware
+// Source: https://github.com/zenazn/goji/blob/master/web/middleware/nocache.go
+
+import (
+	"net/http"
+	"time"
+)
+
+// NoCache is a simple piece of middleware that sets a number of HTTP headers to prevent
+// a router (or subrouter) from being cached by an upstream proxy and/or client.
+//
+// As per http://wiki.nginx.org/HttpProxyModule - NoCache sets:
+//      Expires: Thu, 01 Jan 1970 00:00:00 UTC
+//      Cache-Control: no-cache, private, max-age=0
+//      X-Accel-Expires: 0
+//      Pragma: no-cache (for HTTP/1.0 proxies/clients)
+
+func NoCache(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+		// Unix epoch time
+		var epoch = time.Unix(0, 0).Format(time.RFC1123)
+
+		// Taken from https://github.com/mytrile/nocache
+		var noCacheHeaders = map[string]string{
+			"Expires":         epoch,
+			"Cache-Control":   "no-cache, no-store, no-transform, must-revalidate, private, max-age=0",
+			"Pragma":          "no-cache",
+			"X-Accel-Expires": "0",
+		}
+
+		var etagHeaders = []string{
+			"ETag",
+			"If-Modified-Since",
+			"If-Match",
+			"If-None-Match",
+			"If-Range",
+			"If-Unmodified-Since",
+		}
+
+		// Delete any ETag headers that may have been set
+		for _, v := range etagHeaders {
+			if req.Header.Get(v) != "" {
+				req.Header.Del(v)
+			}
+		}
+
+		// Set our NoCache headers
+		for k, v := range noCacheHeaders {
+			w.Header().Set(k, v)
+		}
+
+		next.ServeHTTP(w, req)
+		
+	})
+}

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -1,0 +1,39 @@
+package middleware
+
+// Adapted from Goji's recoverer middleware
+// Source: https://github.com/zenazn/goji/blob/master/web/middleware/recoverer.go
+
+import (
+	"log"
+	"net/http"
+	"runtime/debug"
+)
+
+func Recoverer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+		// Get unique requestID from request Context
+		requestID := GetRequestID(req.Context())
+
+		defer func() {
+			err := recover()
+			if err != nil {
+				
+				if requestID != "" {
+					log.Println("RequestID: " + requestID)
+				}
+
+				log.Printf("Panic : %+v", err)
+				debug.PrintStack()
+
+				// Internal server error; No more writes to this Writer
+				http.Error(w, http.StatusText(500), 500)
+
+			}
+
+		}()
+
+		next.ServeHTTP(w, req)
+
+	})
+}

--- a/middleware/requestID.go
+++ b/middleware/requestID.go
@@ -1,0 +1,81 @@
+package middleware 
+
+// Adapted from Goji's request_id middleware
+// Source: https://github.com/zenazn/goji/blob/master/web/middleware/request_id.go
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+var RequestIDHeader = "X-Request-ID"
+var prefix string
+var reqid uint64
+
+// A quick note on the statistics here: we're trying to calculate the chance that
+// two randomly generated base62 prefixes will collide. We use the formula from
+// http://en.wikipedia.org/wiki/Birthday_problem
+//
+// P[m, n] \approx 1 - e^{-m^2/2n}
+//
+// We ballpark an upper bound for $m$ by imagining (for whatever reason) a server
+// that restarts every second over 10 years, for $m = 86400 * 365 * 10 = 315360000$
+//
+// For a $k$ character base-62 identifier, we have $n(k) = 62^k$
+//
+// Plugging this in, we find $P[m, n(10)] \approx 5.75%$, which is good enough for
+// our purposes, and is surely more than anyone would ever need in practice -- a
+// process that is rebooted a handful of times a day for a hundred years has less
+// than a millionth of a percent chance of generating two colliding IDs.
+
+func init() {
+	hostname, err := os.Hostname()
+	if hostname == "" || err != nil {
+		hostname = "localhost"
+	}
+	var buf [12]byte
+	var b64 string
+	for len(b64) < 10 {
+		rand.Read(buf[:])
+		b64 = base64.StdEncoding.EncodeToString(buf[:])
+		b64 = strings.NewReplacer("+", "", "/", "").Replace(b64)
+	}
+
+	prefix = fmt.Sprintf("%s/%s", hostname, b64[0:10])
+}
+
+// RequestID is a middleware that injects a request ID into the context of each
+// request. A request ID is a string of the form "host.example.com/random-0001",
+// where "random" is a base62 random string that uniquely identifies this go
+// process, and where the last number is an atomically incremented request
+// counter.
+
+func RequestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestID := req.Header.Get(RequestIDHeader)
+		if requestID == "" {
+			myid := atomic.AddUint64(&reqid, 1)
+			requestID = fmt.Sprintf("%s-%06d", prefix, myid)
+		}
+		ctx := context.WithValue(req.Context(), "requestID", requestID)
+		next.ServeHTTP(w, req.WithContext(ctx))
+	})
+}
+
+// GetReqID returns a request ID from the given context if one is present.
+// Returns the empty string if a request ID cannot be found.
+func GetRequestID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if requestID, ok := ctx.Value("requestID").(string); ok {
+		return requestID
+	}
+	return ""
+}


### PR DESCRIPTION
Some essential middleware are provided out of the box in `github.com/saurabh0719/jett/middleware` - 
- `RequestID` : Injects a request ID into the context of each
request

- `Logger` : Log request paths, methods, status code as well as execution duration 
- `Recoverer` : Recover and handle `panic` 
- `NoCache` : Sets a number of HTTP headers to prevent
a router (or subrouter) from being cached by an upstream proxy and/or client
- `BasicAuth` : Basic Auth middleware, [RFC 2617, Section 2](https://www.rfc-editor.org/rfc/rfc2617.html#section-2)

Changed `PathParams` to `URLParams` and updated the docs.