### PR TITLE
Wmattei/request id with custom header

### DIFF
--- a/jett_test.go
+++ b/jett_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/saurabh0719/jett/middleware"
 )
 
 func TestURLParams(t *testing.T) {
@@ -76,8 +74,6 @@ func TestSubrouter(t *testing.T) {
 }
 
 func Home(w http.ResponseWriter, req *http.Request) {
-	reqID := req.Context().Value("requestID")
-	println(reqID)
 	params := URLParams(req)
 	JSON(w, params, 200)
 }
@@ -85,29 +81,4 @@ func Home(w http.ResponseWriter, req *http.Request) {
 func About(w http.ResponseWriter, req *http.Request) {
 	params := QueryParams(req)
 	JSON(w, params, 200)
-}
-
-func TestRequestIDMiddleware(t *testing.T) {
-	r := New()
-
-	r.Use(middleware.RequestIDWithCustomHeaderStrKey("X-Request-ID"))
-
-	r.GET("/", Home)
-
-	ts := httptest.NewServer(r)
-	defer ts.Close()
-
-	req, err := http.NewRequest("GET", ts.URL, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if res.StatusCode != 200 {
-		t.Fatalf("RequestIDMiddleware -> Expected : 200, Output : %d", res.StatusCode)
-	}
 }

--- a/jett_test.go
+++ b/jett_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/saurabh0719/jett/middleware"
 )
 
 func TestURLParams(t *testing.T) {
@@ -74,6 +76,8 @@ func TestSubrouter(t *testing.T) {
 }
 
 func Home(w http.ResponseWriter, req *http.Request) {
+	reqID := req.Context().Value("requestID")
+	println(reqID)
 	params := URLParams(req)
 	JSON(w, params, 200)
 }
@@ -81,4 +85,29 @@ func Home(w http.ResponseWriter, req *http.Request) {
 func About(w http.ResponseWriter, req *http.Request) {
 	params := QueryParams(req)
 	JSON(w, params, 200)
+}
+
+func TestRequestIDMiddleware(t *testing.T) {
+	r := New()
+
+	r.Use(middleware.RequestIDWithCustomHeaderStrKey("X-Request-ID"))
+
+	r.GET("/", Home)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.StatusCode != 200 {
+		t.Fatalf("RequestIDMiddleware -> Expected : 200, Output : %d", res.StatusCode)
+	}
 }

--- a/middleware/requestID.go
+++ b/middleware/requestID.go
@@ -55,17 +55,6 @@ func init() {
 // where "random" is a base62 random string that uniquely identifies this go
 // process, and where the last number is an atomically incremented request
 // counter.
-
-func RequestIDWithCustomHeaderStrKey(headerStrKey string) func(next http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			requestID := req.Header.Get(headerStrKey)
-			ctx := context.WithValue(req.Context(), "requestID", requestID)
-			next.ServeHTTP(w, req.WithContext(ctx))
-		})
-	}
-}
-
 func RequestID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		requestID := req.Header.Get(defaultRequestIDHeader)
@@ -76,6 +65,19 @@ func RequestID(next http.Handler) http.Handler {
 		ctx := context.WithValue(req.Context(), "requestID", requestID)
 		next.ServeHTTP(w, req.WithContext(ctx))
 	})
+}
+
+// RequestIDWithCustomHeaderStrKey is a middleware that injects a request ID into the context of each
+// request. Different from RequestID, this middleware uses a custom header key to get the request ID,
+// and does not generate a new request ID if the custom header key is not present.
+func RequestIDWithCustomHeaderStrKey(headerStrKey string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			requestID := req.Header.Get(headerStrKey)
+			ctx := context.WithValue(req.Context(), "requestID", requestID)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	}
 }
 
 // GetReqID returns a request ID from the given context if one is present.

--- a/middleware/requestID_test.go
+++ b/middleware/requestID_test.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/saurabh0719/jett"
+)
+
+func handler(w http.ResponseWriter, req *http.Request) {
+	reqID := req.Context().Value("requestID")
+	jett.JSON(w, reqID, 200)
+}
+
+func TestMiddlewareRequestIDWithCustomHeaderStrKey(t *testing.T) {
+	var headerKey = "X-Request-ID"
+	var headerValue = "12345"
+	r := jett.New()
+
+	r.Use(RequestIDWithCustomHeaderStrKey(headerKey))
+
+	r.GET("/", handler)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	req.Header.Set(headerKey, headerValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+
+	// Convert []byte to string
+	var requestId string
+	json.Unmarshal(body, &requestId)
+
+	if requestId != headerValue {
+		t.Fatalf("middleware.RequestID -> Expected : %s, Output : %s", headerValue, requestId)
+	}
+}


### PR DESCRIPTION
This PR is related to #8.

I am creating a new middleware similar to `RequestID` but it gets a parameter where the developer can tell which header key will be used to get the requestId.

Also, it won't generate a new requestId if the header is no present as this assumes that there will always be a header.

Apart of that, I've also created a test file for this new middleware.